### PR TITLE
Renamed to lack of authorization leads to account takeover

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -203,7 +203,6 @@ This is like a social media application so it consist some of the similar featur
 <h4>Low</h4>
  <ul>
     <li>Self XSS</li>
-    <li>CSRF(Cross-site Request Forgery)</li>
     <li>Hidden directories</li>
     <li>No Password Policy</li>
     <li>Weak Reset Password Implementation</li>
@@ -226,7 +225,7 @@ This is like a social media application so it consist some of the similar featur
     <li>Stored XSS(2)</li>
     <li>SSRF(Server-side Request Forgery)</li>
     <li>Blind SSRF</li>
-    <li>Account takeover via IDOR</li>
+    <li>Lack of authorization leads to account takeover</li>
     <li>Chainning of IDOR with XSS</li>
  </ul>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -72,7 +72,7 @@ This is like a social media application so it consist some of the similar featur
     <li>Stored XSS(2)</li>
     <li>SSRF(Server-side Request Forgery)</li>
     <li>Blind SSRF</li>
-    <li>Account takeover via IDOR</li>
+    <li>Lack of authorization leads to account takeover</li>
     <li>Chainning of IDOR with XSS</li>
  </ul>
 


### PR DESCRIPTION
Renamed "Account takeover via IDOR" to "Lack of authorization leads to account takeover"